### PR TITLE
Add VS Code extension for Cucumber in recommended list

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,5 +1,6 @@
 {
   "recommendations": [
+    "alexkrechik.cucumberautocomplete",
     "redhat.vscode-didact",
     "redhat.apache-camel-extension-pack"
   ]


### PR DESCRIPTION
given that there are several Yaks tests (which are specific Cucumber
tests)

Signed-off-by: Aurélien Pupier <apupier@redhat.com>