### PR TITLE
fix(ENTESB-17058): Fix YAKS tests

### DIFF
--- a/CrimeBridge.java
+++ b/CrimeBridge.java
@@ -1,5 +1,6 @@
 // camel-k: language=java property=file:application.properties
-// camel-k: dependency=mvn:org.amqphub.quarkus:quarkus-qpid-jms dependency=github:openshift-integration:camel-k-example-event-streaming
+// camel-k: dependency=mvn:org.amqphub.quarkus:quarkus-qpid-jms
+// camel-k: dependency=github:openshift-integration:camel-k-example-event-streaming
 
 import org.apache.camel.builder.RouteBuilder;
 import org.slf4j.Logger;

--- a/EarthquakeBridge.java
+++ b/EarthquakeBridge.java
@@ -1,5 +1,6 @@
 // camel-k: language=java property=file:application.properties
-// camel-k: dependency=mvn:org.amqphub.quarkus:quarkus-qpid-jms dependency=github:openshift-integration:camel-k-example-event-streaming
+// camel-k: dependency=mvn:org.amqphub.quarkus:quarkus-qpid-jms
+// camel-k: dependency=github:openshift-integration:camel-k-example-event-streaming
 
 import org.apache.camel.builder.RouteBuilder;
 import org.slf4j.Logger;

--- a/HealthBridge.java
+++ b/HealthBridge.java
@@ -1,5 +1,6 @@
 // camel-k: language=java property=file:application.properties
-// camel-k: dependency=mvn:org.amqphub.quarkus:quarkus-qpid-jms dependency=github:openshift-integration:camel-k-example-event-streaming
+// camel-k: dependency=mvn:org.amqphub.quarkus:quarkus-qpid-jms
+// camel-k: dependency=github:openshift-integration:camel-k-example-event-streaming
 
 import org.apache.camel.builder.RouteBuilder;
 import org.slf4j.Logger;

--- a/OpenAQConsumer.java
+++ b/OpenAQConsumer.java
@@ -1,7 +1,6 @@
 // camel-k: language=java property=file:application.properties
 // camel-k: dependency=github:openshift-integration:camel-k-example-event-streaming
-// camel-k: dependency=camel-http
-// camel-k: dependency=camel-quarkus-http
+// camel-k: dependency=camel:http
 
 import static java.util.stream.Collectors.toList;
 

--- a/PollutionBridge.java
+++ b/PollutionBridge.java
@@ -1,5 +1,6 @@
 // camel-k: language=java property=file:application.properties
-// camel-k: dependency=mvn:org.amqphub.quarkus:quarkus-qpid-jms dependency=github:openshift-integration:camel-k-example-event-streaming
+// camel-k: dependency=mvn:org.amqphub.quarkus:quarkus-qpid-jms
+// camel-k: dependency=github:openshift-integration:camel-k-example-event-streaming
 
 import org.apache.camel.builder.RouteBuilder;
 import org.slf4j.Logger;

--- a/TimelineBridge.java
+++ b/TimelineBridge.java
@@ -1,5 +1,6 @@
 // camel-k: language=java property=file:application.properties property=quarkus.http.cors=true
-// camel-k: dependency=camel-jackson dependency=github:openshift-integration:camel-k-example-event-streaming
+// camel-k: dependency=camel:jackson
+// camel-k: dependency=github:openshift-integration:camel-k-example-event-streaming
 
 import java.util.ArrayList;
 import java.util.List;

--- a/infra/messaging/broker/instances/amq-broker-instance.yaml
+++ b/infra/messaging/broker/instances/amq-broker-instance.yaml
@@ -5,6 +5,13 @@ metadata:
 spec:
   deploymentPlan:
     size: 1
+    persistenceEnabled: false
+    requireLogin: false
+    messageMigration: false
+    managementRBACEnabled: true
+    journalType: nio
+    jolokiaAgentEnabled: false
+    image: placeholder
   acceptors:
     - name: artemis_acceptor
       protocols: artemis,core,openwire

--- a/test/application-test.properties
+++ b/test/application-test.properties
@@ -15,5 +15,9 @@ messaging.ttl.notifications=3600000
 kafka.bootstrap.address=event-streaming-kafka-cluster-kafka-bootstrap:9092
 quarkus.qpid-jms.url=amqp://broker-hdls-svc:5672
 
+# Bridge message broker configuration
+messaging.broker.url.amqp=amqp://broker-hdls-svc:5672
+messaging.broker.url=tcp://broker-hdls-svc:61616
+
 # Auth
 users.allowed=user1,user2,user3

--- a/test/application-test.properties
+++ b/test/application-test.properties
@@ -1,0 +1,19 @@
+# Interval between fetching the data from the public APIs
+consumers.fetch.period=5000
+
+# Max records to fetch from public APIs (when applicable)
+consumers.fetch.limit=1000
+
+# URL of the remote service (need to mock in tests)
+consumers.fetch.url=http://openaq-mock:8080/measurements.json
+
+# TTL for the notifications sent to the messaging broker
+messaging.ttl.alarms=86400000
+messaging.ttl.notifications=3600000
+
+# Addresses
+kafka.bootstrap.address=event-streaming-kafka-cluster-kafka-bootstrap:9092
+quarkus.qpid-jms.url=amqp://broker-hdls-svc:5672
+
+# Auth
+users.allowed=user1,user2,user3

--- a/test/bridges/CrimeBridge.feature
+++ b/test/bridges/CrimeBridge.feature
@@ -2,12 +2,18 @@
 Feature: Crime bridge test
 
   Background:
+    Given Disable auto removal of Camel-K resources
+    Given Disable variable support in Camel-K sources
     Given Kafka connection
         | url       | event-streaming-kafka-cluster-kafka-bootstrap:9092 |
         | topic     | crime-data |
     And JMS connection factory
         | type      | org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory |
-        | brokerUrl | tcp://broker-hdls-svc:61616     |
+        | brokerUrl | tcp://broker-hdls-svc:61616 |
+
+  Scenario: Run CrimeBridge Camel-K integration
+    Given Camel-K integration property file application-test.properties
+    Then load Camel-K integration CrimeBridge.java
 
   Scenario: Alerts ends in JMS queue:alarms
     Given jms destination: alarms

--- a/test/bridges/EarthquakeBridge.feature
+++ b/test/bridges/EarthquakeBridge.feature
@@ -2,12 +2,18 @@
 Feature: Earthquake bridge test
 
   Background:
+    Given Disable auto removal of Camel-K resources
+    Given Disable variable support in Camel-K sources
     Given Kafka connection
         | url       | event-streaming-kafka-cluster-kafka-bootstrap:9092 |
         | topic     | earthquake-data |
     And JMS connection factory
         | type      | org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory |
-        | brokerUrl | tcp://broker-hdls-svc:61616     |
+        | brokerUrl | tcp://broker-hdls-svc:61616 |
+
+  Scenario: Run EarthquakeBridge Camel-K integration
+    Given Camel-K integration property file application-test.properties
+    Then load Camel-K integration EarthquakeBridge.java
 
   Scenario: Alerts ends in JMS queue:alarms and queue:notifications
     Given variable title is "citrus:randomString(10)"
@@ -67,7 +73,7 @@ Feature: Earthquake bridge test
       "severity": "red"
     }
     """
-    
+
 Scenario: Non-alert message with magnitude > 4.0 ends in JMS queue:alarms and queue:notifications
     Given variable title is "citrus:randomString(10)"
     And jms selector: title='${title}'
@@ -185,4 +191,4 @@ Scenario: Non-alert message with tsunami warning ends in JMS queue:alarms and qu
       "severity": "red"
     }
     """
-    
+

--- a/test/bridges/HealthBridge.feature
+++ b/test/bridges/HealthBridge.feature
@@ -2,12 +2,18 @@
 Feature: Health bridge test
 
   Background:
+    Given Disable auto removal of Camel-K resources
+    Given Disable variable support in Camel-K sources
     Given Kafka connection
         | url       | event-streaming-kafka-cluster-kafka-bootstrap:9092 |
         | topic     | health-data |
     And JMS connection factory
         | type      | org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory |
-        | brokerUrl | tcp://broker-hdls-svc:61616     |
+        | brokerUrl | tcp://broker-hdls-svc:61616 |
+
+  Scenario: Run HealthBridge Camel-K integration
+    Given Camel-K integration property file application-test.properties
+    Then load Camel-K integration HealthBridge.java
 
   Scenario: Alerts ends in JMS queue:alarms
     Given jms destination: alarms
@@ -61,4 +67,4 @@ Feature: Health bridge test
       "text": "There is a health incident on ${location}",
       "severity": "yellow"
     }
-    """ 
+    """

--- a/test/bridges/PollutionBridge.feature
+++ b/test/bridges/PollutionBridge.feature
@@ -2,12 +2,18 @@
 Feature: Pollution bridge test
 
   Background:
+    Given Disable auto removal of Camel-K resources
+    Given Disable variable support in Camel-K sources
     Given Kafka connection
         | url       | event-streaming-kafka-cluster-kafka-bootstrap:9092 |
         | topic     | pm-data |
     And JMS connection factory
         | type      | org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory |
-        | brokerUrl | tcp://broker-hdls-svc:61616     |
+        | brokerUrl | tcp://broker-hdls-svc:61616 |
+
+  Scenario: Run PollutionBridge Camel-K integration
+    Given Camel-K integration property file application-test.properties
+    Then load Camel-K integration PollutionBridge.java
 
   Scenario: Short term alerts ends in JMS queue:alarms
     Given jms destination: alarms

--- a/test/bridges/yaks-config.yaml
+++ b/test/bridges/yaks-config.yaml
@@ -1,6 +1,13 @@
 config:
   namespace:
     temporary: true
+  runtime:
+    resources:
+      - ../../CrimeBridge.java
+      - ../../EarthquakeBridge.java
+      - ../../HealthBridge.java
+      - ../../PollutionBridge.java
+      - ../application-test.properties
 pre:
   - name: Kafka setup
     script: ../scripts/installAMQStreams.sh
@@ -11,7 +18,3 @@ pre:
       # move to project home to verify provided kamel-config.yaml
       cd ../..
       kamel install -w -n ${YAKS_NAMESPACE}
-      kamel run PollutionBridge.java -n ${YAKS_NAMESPACE} -p kafka.bootstrap.address=event-streaming-kafka-cluster-kafka-bootstrap:9092 -p messaging.broker.url.amqp=amqp://broker-hdls-svc:5672
-      kamel run EarthquakeBridge.java -n ${YAKS_NAMESPACE} -p kafka.bootstrap.address=event-streaming-kafka-cluster-kafka-bootstrap:9092 -p messaging.broker.url=tcp://broker-hdls-svc:61616
-      kamel run HealthBridge.java -n ${YAKS_NAMESPACE} -p kafka.bootstrap.address=event-streaming-kafka-cluster-kafka-bootstrap:9092 -p messaging.broker.url=tcp://broker-hdls-svc:61616
-      kamel run CrimeBridge.java -n ${YAKS_NAMESPACE} -p kafka.bootstrap.address=event-streaming-kafka-cluster-kafka-bootstrap:9092 -p messaging.broker.url=tcp://broker-hdls-svc:61616

--- a/test/consumers/EarthquakeConsumer.feature
+++ b/test/consumers/EarthquakeConsumer.feature
@@ -1,4 +1,5 @@
 @require('com.consol.citrus:citrus-validation-hamcrest:@citrus.version@')
+@require('org.hamcrest:hamcrest:2.2')
 Feature: Earthquake consumer test
 
   Background:

--- a/test/consumers/EarthquakeConsumer.feature
+++ b/test/consumers/EarthquakeConsumer.feature
@@ -3,9 +3,15 @@
 Feature: Earthquake consumer test
 
   Background:
+    Given Disable auto removal of Camel-K resources
+    Given Disable variable support in Camel-K sources
     Given Kafka connection
         | url       | event-streaming-kafka-cluster-kafka-bootstrap:9092 |
         | topic     | earthquake-data |
+
+  Scenario: Run EarthquakeConsumer Camel-K integration
+    Given Camel-K integration property file application-test.properties
+    Then load Camel-K integration EarthquakeConsumer.java
 
   Scenario: EarthquakeConsumer pulls from USGS Earthquake API and pushes events to Kafka
     Given Camel-K integration earthquake-consumer is running

--- a/test/consumers/OpenAQConsumer.feature
+++ b/test/consumers/OpenAQConsumer.feature
@@ -3,13 +3,19 @@
 Feature: OpenAQ consumer test
 
   Background:
+    Given Disable auto removal of Camel-K resources
+    Given Disable variable support in Camel-K sources
     Given Kafka connection
         | url       | event-streaming-kafka-cluster-kafka-bootstrap:9092 |
         | topic     | pm-data |
 
+  Scenario: Run OpenAQConsumer Camel-K integration
+    Given Camel-K integration property file application-test.properties
+    Then load Camel-K integration OpenAQConsumer.java
+
   Scenario: OpenAQConsumer pulls from OpenAQ API and pushes events to Kafka
-    Given Camel-K integration open-aq-consumer is running
-    Then Camel-K integration open-aq-consumer should print Received message from OpenAQ
+    Given Camel-K integration open-aqconsumer is running
+    Then Camel-K integration open-aqconsumer should print Received message from OpenAQ
     And expect Kafka message with body
     """
     {

--- a/test/consumers/OpenAQConsumer.feature
+++ b/test/consumers/OpenAQConsumer.feature
@@ -1,9 +1,10 @@
 @require('com.consol.citrus:citrus-validation-hamcrest:@citrus.version@')
+@require('org.hamcrest:hamcrest:2.2')
 Feature: OpenAQ consumer test
 
   Background:
     Given Kafka connection
-        | url       | event-streaming-kafka-cluster-kafka-brokers:9094 |
+        | url       | event-streaming-kafka-cluster-kafka-bootstrap:9092 |
         | topic     | pm-data |
 
   Scenario: OpenAQConsumer pulls from OpenAQ API and pushes events to Kafka

--- a/test/consumers/yaks-config.yaml
+++ b/test/consumers/yaks-config.yaml
@@ -12,5 +12,5 @@ pre:
       # move to project home to verify provided kamel-config.yaml
       cd ../..
       kamel install -w -n ${YAKS_NAMESPACE}
-      kamel run OpenAQConsumer.java -n ${YAKS_NAMESPACE} -p kafka.bootstrap.address=event-streaming-kafka-cluster-kafka-bootstrap:9092 -p consumers.fetch.url=http://openaq-mock:8080/measurements.json
+      kamel run OpenAQConsumer.java -n ${YAKS_NAMESPACE} -p kafka.bootstrap.address=event-streaming-kafka-cluster-kafka-bootstrap:9092 -p consumers.fetch.url=http://openaq-mock:8080/measurements.json -p consumers.fetch.period=5000
       kamel run EarthquakeConsumer.java -n ${YAKS_NAMESPACE} -p kafka.bootstrap.address=event-streaming-kafka-cluster-kafka-bootstrap:9092

--- a/test/consumers/yaks-config.yaml
+++ b/test/consumers/yaks-config.yaml
@@ -1,6 +1,11 @@
 config:
   namespace:
     temporary: true
+  runtime:
+    resources:
+      - ../../OpenAQConsumer.java
+      - ../../EarthquakeConsumer.java
+      - ../application-test.properties
 pre:
   - name: Kafka setup
     script: ../scripts/installAMQStreams.sh
@@ -12,5 +17,3 @@ pre:
       # move to project home to verify provided kamel-config.yaml
       cd ../..
       kamel install -w -n ${YAKS_NAMESPACE}
-      kamel run OpenAQConsumer.java -n ${YAKS_NAMESPACE} -p kafka.bootstrap.address=event-streaming-kafka-cluster-kafka-bootstrap:9092 -p consumers.fetch.url=http://openaq-mock:8080/measurements.json -p consumers.fetch.period=5000
-      kamel run EarthquakeConsumer.java -n ${YAKS_NAMESPACE} -p kafka.bootstrap.address=event-streaming-kafka-cluster-kafka-bootstrap:9092

--- a/test/scripts/installAMQStreams.sh
+++ b/test/scripts/installAMQStreams.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 function waitFor() {
   for i in {1..30}; do
     sleep 5
@@ -9,20 +11,29 @@ function waitFor() {
   exit 1
 }
 
+AMQ_STREAMS_VERSION="v1.7.2"
 TIMEOUT=${TIMEOUT:-30}
 SOURCE=$(dirname "${BASH_SOURCE[0]}")
 INFRA="${SOURCE}"/../../infra
 
-#create OperatorGroup
-sed "s/YAKS_NAMESPACE/${YAKS_NAMESPACE}/" "${SOURCE}"/resources/operatorGroup.yaml | oc create -f - 2> /dev/null || echo "OperatorGroup already exists"
+CSV=$(oc get csv amqstreams.${AMQ_STREAMS_VERSION} -n ${YAKS_NAMESPACE} || echo "ERROR: failed to find AMQ Streams CSV")
+#check for existing amq-streams subscription
+if [ "${CSV//ERROR/}" != "${CSV}" ]; then
+  echo "Create AMQ Streams subscription"
 
-#install amq streams using OLM
-oc create -f "${SOURCE}"/resources/amq-streams-subscription.yaml -n ${YAKS_NAMESPACE}
+  #create OperatorGroup
+  sed "s/YAKS_NAMESPACE/${YAKS_NAMESPACE}/" "${SOURCE}"/resources/operatorGroup.yaml | oc create -f - 2> /dev/null || echo "OperatorGroup already exists"
 
-#ensure operator pod is deployed and Ready
-waitFor oc wait pod -l name=amq-streams-cluster-operator --for condition=Ready --timeout=60s -n ${YAKS_NAMESPACE}
+  #install AMQ streams using OLM
+  oc create -f "${SOURCE}"/resources/amq-streams-subscription.yaml -n ${YAKS_NAMESPACE}
 
-#create Kafka
+  #ensure operator pod is deployed and Ready
+  waitFor oc wait pod -l name=amq-streams-cluster-operator --for condition=Ready --timeout=60s -n ${YAKS_NAMESPACE}
+else
+  echo "AMQ Streams subscription already exists"
+fi
+
+#create Kafka cluster
 oc create -f "${INFRA}"/kafka/clusters/event-streaming-cluster.yaml -n ${YAKS_NAMESPACE}
 oc wait kafka/event-streaming-kafka-cluster --for=condition=Ready --timeout=600s -n ${YAKS_NAMESPACE}
 

--- a/test/scripts/resources/amq-broker-subscription.yaml
+++ b/test/scripts/resources/amq-broker-subscription.yaml
@@ -3,7 +3,7 @@ kind: Subscription
 metadata:
   name: amq-broker
 spec:
-  channel: current
+  channel: 7.x
   installPlanApproval: Automatic
   name: amq-broker
   source: redhat-operators

--- a/test/user-report/UserReportCrime.feature
+++ b/test/user-report/UserReportCrime.feature
@@ -1,19 +1,29 @@
 Feature: User report and gate-keeper component test
 
   Background:
-    Given Camel-K integration user-report-system should be running
-    And Camel-K integration gate-keeper should be running
-    Given HTTP request timeout is 60000 ms
     Given URL: http://user-report-system.${YAKS_NAMESPACE}.svc.cluster.local
-    Given HTTP request header Content-Type is "application/json"
-    Given variable user is "user1"
-
-  Scenario: Crime report is send to crime-data topic
+    Given HTTP request timeout is 60000 ms
     Given Kafka connection
       | url           | event-streaming-kafka-cluster-kafka-bootstrap:9092 |
       | topic         | crime-data |
       | consumerGroup | crime      |
+
+  Scenario: Run UserReportSystem Camel-K integration
+    Given Camel-K integration property file application-test.properties
+    When load Camel-K integration UserReportSystem.java with configuration
+      | traits | knative-service.min-scale=1 |
+    Then Camel-K integration user-report-system should be running
+
+  Scenario: Run GateKeeper Camel-K integration
+    Given Camel-K integration property file application-test.properties
+    When load Camel-K integration GateKeeper.java with configuration
+      | traits | knative-service.min-scale=1 |
+    Given Camel-K integration gate-keeper should be running
+
+  Scenario: Crime report is send to crime-data topic
+    Given variable user is "user1"
     And variable location is "citrus:randomString(10)"
+    And HTTP request header Content-Type is "application/json"
     And HTTP request body
     """
       {

--- a/test/user-report/UserReportHealth.feature
+++ b/test/user-report/UserReportHealth.feature
@@ -1,25 +1,29 @@
 Feature: Health user report and gate-keeper component test
 
   Background:
-    Given Camel-K integration user-report-system should be running
-    And Camel-K integration gate-keeper should be running
-    Given HTTP request timeout is 60000 ms
     Given URL: http://user-report-system.${YAKS_NAMESPACE}.svc.cluster.local
-    Given HTTP request header Content-Type is "application/json"
-    Given variable user is "user1"
-
-  Scenario: Health report is send to health-data topic
-    Given Camel-K integration user-report-system should be running
-    And Camel-K integration gate-keeper should be running
     Given HTTP request timeout is 60000 ms
-    Given URL: http://user-report-system.${YAKS_NAMESPACE}.svc.cluster.local
-    Given HTTP request header Content-Type is "application/json"
-    Given variable user is "user1"
     Given Kafka connection
       | url           | event-streaming-kafka-cluster-kafka-bootstrap:9092 |
       | topic         | health-data |
       | consumerGroup | health      |
+
+  Scenario: Run UserReportSystem Camel-K integration
+    Given Camel-K integration property file application-test.properties
+    When load Camel-K integration UserReportSystem.java with configuration
+      | traits | knative-service.min-scale=1 |
+    Then Camel-K integration user-report-system should be running
+
+  Scenario: Run GateKeeper Camel-K integration
+    Given Camel-K integration property file application-test.properties
+    When load Camel-K integration GateKeeper.java with configuration
+      | traits | knative-service.min-scale=1 |
+    Given Camel-K integration gate-keeper should be running
+
+  Scenario: Health report is send to health-data topic
+    Given variable user is "user1"
     And variable location is "citrus:randomString(10)"
+    And HTTP request header Content-Type is "application/json"
     And HTTP request body
     """
       {
@@ -35,7 +39,6 @@ Feature: Health user report and gate-keeper component test
       }
     """
     When send PUT /report/new
-    Then Camel-K integration user-report-system should be running
     And receive HTTP 200
     And expect HTTP response body: OK
     And verify Kafka message body

--- a/test/user-report/yaks-config.yaml
+++ b/test/user-report/yaks-config.yaml
@@ -1,11 +1,16 @@
 config:
   namespace:
     temporary: true
+  runtime:
+    resources:
+      - ../../UserReportSystem.java
+      - ../../GateKeeper.java
+      - ../application-test.properties
 pre:
   - name: Knative channel setup
     run: oc create -f ../../infra/knative/channels/audit-channel.yaml -n ${YAKS_NAMESPACE}
   - name: Create secret
-    run: oc create secret generic example-event-streaming-user-reporting --from-file ../../application.properties -n ${YAKS_NAMESPACE}
+    run: oc create secret generic example-event-streaming-user-reporting --from-file ../application-test.properties -n ${YAKS_NAMESPACE}
   - name: Kafka setup
     script: ../scripts/installAMQStreams.sh
   - name: Camel-K setup
@@ -13,6 +18,3 @@ pre:
       # move to project home to verify provided kamel-config.yaml
       cd ../..
       kamel install -w -n ${YAKS_NAMESPACE}
-      kamel run UserReportSystem.java -n ${YAKS_NAMESPACE} -p kafka.bootstrap.address=event-streaming-kafka-cluster-kafka-bootstrap:9092 -t knative-service.min-scale=1
-      kamel run GateKeeper.java -n ${YAKS_NAMESPACE} -t knative-service.min-scale=1
-


### PR DESCRIPTION
- Fix features to run with YAKS 0.5.x
- Check for existing subscriptions on cluster in pre scripts
Need to check that there is no global AMQ Streams OLM subscription already available on the cluster. Adding a 2nd subscription will fail the YAKS prepare test scripts.
Make sure to only add the subscription when no global one is present on the cluster.
- Run Camel-K integrations as part of the test
Remove `kamel run` from prepare scripts
Add Camel-K integrations as resources to the test and run those as part of the test. Only runs the integration required for the individual test.
- Use explicit application-test.properties
- Use uniform camel and camel-quarkus dependencies with `camel:` prefix
- Fix AMQ broker instance configuration