### PR TITLE
[ENTESB-18554] Updated version to 3.0.0

### DIFF
--- a/infra/kafka/clusters/event-streaming-cluster.yaml
+++ b/infra/kafka/clusters/event-streaming-cluster.yaml
@@ -8,9 +8,9 @@ spec:
       offsets.topic.replication.factor: 1
       transaction.state.log.replication.factor: 1
       transaction.state.log.min.isr: 1
-      log.message.format.version: '2.7'
-      inter.broker.protocol.version: '2.7'
-    version: 2.7.0
+      log.message.format.version: '3.0'
+      inter.broker.protocol.version: '3.0'
+    version: 3.0.0
     storage:
       type: ephemeral
     replicas: 1


### PR DESCRIPTION
There is hardcoded [version 2.7.0 in yaml resource](https://github.com/openshift-integration/camel-k-example-event-streaming/blob/1.6.x/infra/kafka/clusters/event-streaming-cluster.yaml#L13) for creating Kafka instance; if I follow in the quickstart the step `oc create -f infra/kafka/clusters/event-streaming-cluster.yaml` with latest released AMQ Streams operator (AMQ Streams 2.0.1-0, redhat operators, stable), the kafka instance results in invalid state:

```
status:
  conditions:
  - lastTransitionTime: "2022-02-17T21:18:27.078Z"
    message: 'Version 2.7.0 is not supported. Supported versions are: 2.8.0, 3.0.0.'
    reason: InvalidResourceException
    status: "True"
    type: NotReady
  observedGeneration: 1
```