### PR TITLE
[ENTESB-18559] Typo in kafka instance url

### DIFF
--- a/test/consumers/OpenAQConsumer.feature
+++ b/test/consumers/OpenAQConsumer.feature
@@ -3,7 +3,7 @@ Feature: OpenAQ consumer test
 
   Background:
     Given Kafka connection
-        | url       | event-streaming-kafka-cluster-kafka-brokers:9094 |
+        | url       | event-streaming-kafka-cluster-kafka-bootstrap:9092 |
         | topic     | pm-data |
 
   Scenario: OpenAQConsumer pulls from OpenAQ API and pushes events to Kafka


### PR DESCRIPTION
@christophd I think there is a typo in the url, the test currently ends in error `com.consol.citrus.exceptions.MessageTimeoutException: Action timeout after 60000 milliseconds. Failed to receive message on endpoint: 'pm-data'`, also in the namespace `event-streaming-kafka-cluster` is created just Kafka instance (broker is in other namespace `event-streaming-messaging-broker`...)
